### PR TITLE
feat: enhance incident reports functionality

### DIFF
--- a/apps/api/prisma/migrations/20250928142133_add_incident_details_to_records/migration.sql
+++ b/apps/api/prisma/migrations/20250928142133_add_incident_details_to_records/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "RecordType" ADD VALUE 'INCIDENT_REPORT';
+
+-- AlterTable
+ALTER TABLE "Record" ADD COLUMN     "incidentDetails" TEXT;

--- a/apps/api/prisma/migrations/20250928142945_remove_incident_details_from_records/migration.sql
+++ b/apps/api/prisma/migrations/20250928142945_remove_incident_details_from_records/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `incidentDetails` on the `Record` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Record" DROP COLUMN "incidentDetails";

--- a/apps/client/locales/en/leo.json
+++ b/apps/client/locales/en/leo.json
@@ -27,6 +27,7 @@
     "createWrittenWarning": "Create Written Warning",
     "createIncidentReport": "Create Incident Report",
     "editIncidentReport": "Edit Incident Report",
+    "narrative": "Narrative",
     "createBolo": "Create Bolo",
     "nameSearch": "Name Search",
     "addressSearch": "Address Search",

--- a/apps/client/src/components/leo/modals/NameSearchModal/tabs/tabs-container.tsx
+++ b/apps/client/src/components/leo/modals/NameSearchModal/tabs/tabs-container.tsx
@@ -35,6 +35,9 @@ export function NameSearchTabsContainer() {
   const writtenWarningsLength = currentResult.Record.filter(
     (v) => v.type === RecordType.WRITTEN_WARNING,
   ).length;
+  const incidentReportsLength = currentResult.Record.filter(
+    (v) => v.type === RecordType.INCIDENT_REPORT,
+  ).length;
   const warrantsLength = currentResult.warrants.length;
   const notesLength = currentResult.notes?.length ?? 0;
 
@@ -44,6 +47,7 @@ export function NameSearchTabsContainer() {
     { value: "tickets", name: `${t("Leo.tickets")} (${ticketsLength})` },
     { value: "arrestReports", name: `${t("Leo.arrestReports")} (${arrestReportsLength})` },
     { value: "writtenWarnings", name: `${t("Leo.writtenWarnings")} (${writtenWarningsLength})` },
+    { value: "incidentReports", name: `${t("Leo.incidentReports")} (${incidentReportsLength})` },
     { value: "warrants", name: `${t("Leo.warrants")} (${warrantsLength})` },
     { value: "notes", name: `${t("Leo.notes")} (${notesLength})` },
   ];

--- a/apps/client/src/components/leo/modals/business-search-modal/tabs/tabs-container.tsx
+++ b/apps/client/src/components/leo/modals/business-search-modal/tabs/tabs-container.tsx
@@ -25,6 +25,9 @@ export function BusinessSearchTabsContainer() {
   const writtenWarningsLength = currentResult.Record.filter(
     (v) => v.type === RecordType.WRITTEN_WARNING,
   ).length;
+  const incidentReportsLength = currentResult.Record.filter(
+    (v) => v.type === RecordType.INCIDENT_REPORT,
+  ).length;
 
   const TABS = [
     { name: t("Business.employees"), value: "business-search-employees-tab" },
@@ -32,6 +35,7 @@ export function BusinessSearchTabsContainer() {
     { value: "tickets", name: `${t("Leo.tickets")} (${ticketsLength})` },
     { value: "arrestReports", name: `${t("Leo.arrestReports")} (${arrestReportsLength})` },
     { value: "writtenWarnings", name: `${t("Leo.writtenWarnings")} (${writtenWarningsLength})` },
+    { value: "incidentReports", name: `${t("Leo.incidentReports")} (${incidentReportsLength})` },
   ];
 
   return (

--- a/apps/client/src/components/leo/modals/manage-record/tabs/vehicle-tab/vehicle-tab.tsx
+++ b/apps/client/src/components/leo/modals/manage-record/tabs/vehicle-tab/vehicle-tab.tsx
@@ -43,6 +43,7 @@ export function VehicleTab(props: VehicleTabProps) {
         isDisabled={props.isReadOnly}
         allowsCustomValue
         autoFocus
+        isOptional
         onInputChange={(value) => setFieldValue("plateOrVinSearch", value)}
         onSelectionChange={(node) => {
           if (node?.value) {
@@ -80,6 +81,7 @@ export function VehicleTab(props: VehicleTabProps) {
         isDisabled={props.isReadOnly}
         onChange={(value) => setFieldValue("vehicleModel", value)}
         errorMessage={errors.vehicleModel}
+        isOptional
       />
 
       <TextField
@@ -88,6 +90,7 @@ export function VehicleTab(props: VehicleTabProps) {
         isDisabled={props.isReadOnly}
         onChange={(value) => setFieldValue("vehicleColor", value)}
         errorMessage={errors.vehicleColor}
+        isOptional
       />
 
       <FormRow useFlex>

--- a/packages/schemas/src/records.ts
+++ b/packages/schemas/src/records.ts
@@ -50,20 +50,16 @@ export const CREATE_TICKET_SCHEMA = z.object({
 });
 
 export const CREATE_INCIDENT_REPORT_SCHEMA = z.object({
-  type: z.string().min(2).max(255).regex(/INCIDENT_REPORT/),
+  type: z
+    .string()
+    .min(2)
+    .max(255)
+    .regex(/INCIDENT_REPORT/),
   publishStatus: z.string().regex(publishStatus).nullish(),
   citizenId: z.string().min(2).max(255).optional(),
-  violations: z.array(VIOLATION).optional(), // Optional for incident reports
-  seizedItems: z.array(SEIZED_ITEM_SCHEMA).optional(),
   postal: z.string().min(1).max(255),
   notes: z.string().nullish(),
   descriptionData: z.any(),
-  paymentStatus: z
-    .string()
-    .regex(/PAID|UNPAID/)
-    .optional()
-    .nullable(),
-  courtEntry: COURT_ENTRY_SCHEMA.nullish(),
   vehicleId: z.string().nullish(),
   businessId: z.string().nullish(),
   reportFields: z.any().optional(),

--- a/packages/types/src/enums.ts
+++ b/packages/types/src/enums.ts
@@ -244,6 +244,7 @@ export const RecordType = {
   ARREST_REPORT: "ARREST_REPORT",
   TICKET: "TICKET",
   WRITTEN_WARNING: "WRITTEN_WARNING",
+  INCIDENT_REPORT: "INCIDENT_REPORT",
 } as const;
 
 export type RecordType = (typeof RecordType)[keyof typeof RecordType];


### PR DESCRIPTION
- Add incident reports tab to citizen and business search results
- Simplify incident report creation by removing violations, seized items, and court sections
- Rename notes field to 'Narrative' and make it required for incident reports
- Remove 'Record Paid' field from incident reports
- Make vehicle information fields optional for incident reports
- Fix Prisma query errors for expungement request deletion
- Update schemas and types to support incident report enhancements
- Add proper translation keys for incident reports display
